### PR TITLE
Update mainnet L2Claim contract address

### DIFF
--- a/network_info.json
+++ b/network_info.json
@@ -9,6 +9,6 @@
         "liskAPIURL": "https://rpc.api.lisk.com",
         "claimAPIURL": "https://token-claim-api.lisk.com/rpc",
         "network": "lisk",
-        "contractAddress": "0x"
+        "contractAddress": "0xD7BE2Fd98BfD64c1dfCf6c013fC593eF09219994"
     }
 }


### PR DESCRIPTION
### What was the problem?

This PR resolves #1 

### How was it solved?

- Update L2Claim contract address for mainnet in network_info.json
  - Address copied from https://github.com/LiskHQ/lisk-contracts/blob/main/deployment/addresses/mainnet/addresses.md

How was it tested?

NA